### PR TITLE
Add labels to loki service

### DIFF
--- a/loki/loki.libsonnet
+++ b/loki/loki.libsonnet
@@ -204,6 +204,7 @@
     metadata: {
       name: loki.config.name,
       namespace: loki.config.namespace,
+      labels: loki.config.commonLabels,
     },
     spec: {
       ports: [


### PR DESCRIPTION
The Loki Service is missing some labels we want to for ServiceMonitors.